### PR TITLE
Add Typescript types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+declare module 'magic-symbols';
+
+declare function parse(string: string, xterm: boolean): string;
+
+declare function strip(string: string): string;
+
+export interface IMagicSymbolConfig {
+	foreground_symbol?: string;
+	foreground_grayscale_symbol?: string;
+	background_symbol?: string;
+	background_grayscale_symbol?: string;
+	escape_symbol?: string;
+	unescape_symbol?: string;
+  no_hilite_symbol?: string;
+  xtermAliases?: IMagicSymbolXtermAliases
+}
+
+export interface IMagicSymbolXtermAliases {
+  [key: string]: string;
+}
+
+declare function setSyntax(syntaxObject: IMagicSymbolConfig): void;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mux"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "src/init_parser.js",


### PR DESCRIPTION
As I (and a few others) use TypeScript for our Ranvier repos, it's nice to have the types .

I think this is all we need to do and works fine on my end. It's useful for me so I thought I'd see if you would like to include it in your master.