### PR TITLE
Allow for optional xterm paramter in parse function for types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'magic-symbols';
 
-declare function parse(string: string, xterm: boolean): string;
+declare function parse(string: string, xterm?: boolean): string;
 
 declare function strip(string: string): string;
 


### PR DESCRIPTION
The library already has the param xterm defaulting to true, so the typing should allow that param as optional.