### PR TITLE
Feat: Allow for multiple recall tokens to be used in series

### DIFF
--- a/tests/parse.js
+++ b/tests/parse.js
@@ -156,7 +156,27 @@ describe("parse", () => {
     const pstr = parse(str);
     const equivstr = parse(equiv);
 
-    expect(pstr).to.be(equivstr);
+    expect(pstr).to.eql(equivstr);
+  });
+
+  it("Returns first color when recall syntax is out of range", () => {
+    const str = "|rred |bblue |<8red";
+    const equiv = "|rred |bblue |rred";
+
+    const pstr = parse(str);
+    const equivstr = parse(equiv);
+
+    expect(pstr).to.eql(equivstr);
+  });
+
+  it("Returns empty string if no colors are in the stack and recall token is used ", () => {
+    const str = "This has no colors|<2";
+    const equiv = "This has no colors";
+
+    const pstr = parse(str);
+    const equivstr = parse(equiv);
+
+    expect(pstr).to.eql(equivstr);
   });
 
   it("Can recall the last 9 colors with recall syntax", () => {
@@ -242,6 +262,54 @@ describe("parse", () => {
     str = base + "|<1 xterm-bg-gray";
     equiv = base + "|[444 xterm-bg-gray";
 
+    pstr = parse(str);
+    equivstr = parse(equiv);
+    expect(pstr).to.eql(equivstr);
+  });
+
+  it("Can recall with multiple tokens with ansi", () => {
+    const base =
+      "|r bold-red" +
+      "|R red" +
+      "|y bold-yellow" + // |<9
+      "|Y yellow" + // |<8
+      "|g bold-green" + // |<7
+      "|G green" + // |<6
+      "|b bold-blue" + // |<5
+      "|B blue" + // |<4
+      "|c bold-cyan" + // |<3
+      "|C cyan" + // |<2
+      "|m bold-magenta" + // |<1
+      "|M magenta"; // Current
+
+    let str, equiv, pstr, equivstr;
+
+    str = base + "|<3|<3|<2 yellow";
+    equiv = base + "|c|G|Y yellow";
+    pstr = parse(str);
+    equivstr = parse(equiv);
+    expect(pstr).to.eql(equivstr);
+
+    str = base + "|<2|<3|<3 yellow";
+    equiv = base + "|C|b|Y yellow";
+    pstr = parse(str);
+    equivstr = parse(equiv);
+    expect(pstr).to.eql(equivstr);
+
+    str = base + "|<3|<2|<3 yellow";
+    equiv = base + "|c|b|Y yellow";
+    pstr = parse(str);
+    equivstr = parse(equiv);
+    expect(pstr).to.eql(equivstr);
+
+    str = base + "|<1|<1|<1|<1|<1|<1|<1|<1|<1 bold-yellow";
+    equiv = base + "|m|C|c|B|b|G|g|Y|y bold-yellow";
+    pstr = parse(str);
+    equivstr = parse(equiv);
+    expect(pstr).to.eql(equivstr);
+
+    str = base + "|<2 cyan |<3 Blue |<3 yellow";
+    equiv = base + "|C cyan |b Blue |Y yellow";
     pstr = parse(str);
     equivstr = parse(equiv);
     expect(pstr).to.eql(equivstr);


### PR DESCRIPTION
This expands upon the recall token feature that you had added in. Instead of using a circular buffer, I updated to use a simple stack for the color memory.

I use this library on my daily driver game I'm making. I  have code/functions that abstract away constant strings with colors attached. Like `const NONE = '|RNONE|<1'`. I frequently run into cases where I use the NONE variable within some other string that has recall symbols in it already. The original implementation of this does not support something like '|<1|<1', having multiple recall symbols used in series. 

This change lets the parser accept things lis `|<3|<3|<3' and have it be equivalent to a '|<9'.

I've written some tests to cover the cases I've wanted to support and the existing tests still pass. I've also pointed my game's magic-symbols version to this branch  and haven't ran into issues yet. I'll daily drive the this code for a bit.

Let me know if there is anything else you'd like to have included in this PR.

Thanks!